### PR TITLE
Add constraints and indexes

### DIFF
--- a/priv/repo/migrations/20230511004927_add_constraints_to_messages.exs
+++ b/priv/repo/migrations/20230511004927_add_constraints_to_messages.exs
@@ -1,0 +1,12 @@
+defmodule Chat.Repo.Migrations.AddConstraintsToMessages do
+  use Ecto.Migration
+
+  def change do
+    drop constraint("messages", "messages_user_id_fkey")
+
+    alter table("messages") do
+      modify :content, :string, null: false
+      modify :user_id, references(:users), null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20230511005908_add_constraints_to_channels.exs
+++ b/priv/repo/migrations/20230511005908_add_constraints_to_channels.exs
@@ -1,0 +1,11 @@
+defmodule Chat.Repo.Migrations.AddConstraintsToChannels do
+  use Ecto.Migration
+
+  def change do
+    alter table("channels") do
+      modify :name, :string, null: false
+    end
+
+    create index("channels", [:name], unique: true)
+  end
+end

--- a/priv/repo/migrations/20230511010951_add_channel_id_index_to_messages.exs
+++ b/priv/repo/migrations/20230511010951_add_channel_id_index_to_messages.exs
@@ -1,0 +1,7 @@
+defmodule Chat.Repo.Migrations.AddChannelIdIndexToMessages do
+  use Ecto.Migration
+
+  def change do
+    create index("messages", [:channel_id], using: :hash)
+  end
+end


### PR DESCRIPTION
## 개요
`messages`, `channels` 테이블에 nullable 제약 및 index를 추가하는 PR 입니다.

## 변경사항
- `messages` 테이블
  - `content`, `user_id` 필드 nullable=false
  - `channel_id` 필드 인덱스 추가
- `channels` 테이블
  - `name` 필드 nullable=false
  - `name` 필드 unique 인덱스 추가