### PR TITLE
Fix handle_info new_message

### DIFF
--- a/lib/chat_web/live/chat_live.ex
+++ b/lib/chat_web/live/chat_live.ex
@@ -420,7 +420,7 @@ defmodule ChatWeb.ChatLive do
 
   @impl Phoenix.LiveView
   def handle_info({:new_message, message, sender}, socket) do
-    message = Map.put(message, :user, sender)
+    message = message |> Map.put(:user, sender) |> Map.put(:last_sub_message, nil)
 
     socket =
       socket


### PR DESCRIPTION
1. handle_info callback used to update message without last_sub_message field
    - as a result, it was set Ecto.Association.NotLoaded struct which is considered truthy value and caused problem after passing nil check.
    - now sets it to nil